### PR TITLE
update to 9.1.1, switch to new debian package and bin naming scheme

### DIFF
--- a/.github/workflows/external_trigger.yml
+++ b/.github/workflows/external_trigger.yml
@@ -23,7 +23,7 @@ jobs:
           echo "> [!NOTE]" >> $GITHUB_STEP_SUMMARY
           echo "> External trigger running off of master branch. To disable this trigger, add \`qemu-static_master\` into the Github organizational variable \`SKIP_EXTERNAL_TRIGGER\`." >> $GITHUB_STEP_SUMMARY
           printf "\n## Retrieving external version\n\n" >> $GITHUB_STEP_SUMMARY
-          EXT_RELEASE=$(echo 9.0.2+ds-1~bpo12+1)
+          EXT_RELEASE=$(echo 9.1.1+ds-2~bpo12+1)
           echo "Type is \`custom_version_command\`" >> $GITHUB_STEP_SUMMARY
           if [ -z "${EXT_RELEASE}" ] || [ "${EXT_RELEASE}" == "null" ]; then
             echo "> [!WARNING]" >> $GITHUB_STEP_SUMMARY

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@
 
 FROM debian:bookworm AS buildstage
 
-ARG QEMU_VERSION="9.0.2+ds-1~bpo12+1"
+ARG QEMU_VERSION="9.1.1+ds-2~bpo12+1"
 
 RUN \
   echo "**** install build deps ****" && \
@@ -18,7 +18,7 @@ RUN \
     /tmp/qemu && \
   curl -o \
   /tmp/qemu.deb -L \
-    "http://ftp.de.debian.org/debian/pool/main/q/qemu/qemu-user-static_${QEMU_VERSION}_amd64.deb" && \
+    "http://ftp.de.debian.org/debian/pool/main/q/qemu/qemu-user_${QEMU_VERSION}_amd64.deb" && \
   cd /tmp && \
   dpkg-deb -R \
     qemu.deb \

--- a/Dockerfile
+++ b/Dockerfile
@@ -17,7 +17,7 @@ RUN \
     /build-out/usr/bin \
     /tmp/qemu && \
   curl -o \
-  /tmp/qemu.deb -L \
+    /tmp/qemu.deb -L \
     "http://ftp.de.debian.org/debian/pool/main/q/qemu/qemu-user_${QEMU_VERSION}_amd64.deb" && \
   cd /tmp && \
   dpkg-deb -R \
@@ -27,7 +27,7 @@ RUN \
     /tmp/qemu/usr/bin/* \
     /build-out/qemu && \
   curl -o \
-  /build-out/usr/bin/qemu-binfmt-conf -L \
+    /build-out/usr/bin/qemu-binfmt-conf -L \
     "https://raw.githubusercontent.com/qemu/qemu/refs/heads/master/scripts/qemu-binfmt-conf.sh" && \
   chmod +x /build-out/usr/bin/qemu-binfmt-conf
 

--- a/Dockerfile.aarch64
+++ b/Dockerfile.aarch64
@@ -2,7 +2,7 @@
 
 FROM debian:bookworm AS buildstage
 
-ARG QEMU_VERSION="9.0.2+ds-1~bpo12+1"
+ARG QEMU_VERSION="9.1.1+ds-2~bpo12+1"
 
 RUN \
   echo "**** install build deps ****" && \
@@ -18,7 +18,7 @@ RUN \
     /tmp/qemu && \
   curl -o \
   /tmp/qemu.deb -L \
-    "http://ftp.de.debian.org/debian/pool/main/q/qemu/qemu-user-static_${QEMU_VERSION}_arm64.deb" && \
+    "http://ftp.de.debian.org/debian/pool/main/q/qemu/qemu-user_${QEMU_VERSION}_arm64.deb" && \
   cd /tmp && \
   dpkg-deb -R \
     qemu.deb \

--- a/Dockerfile.aarch64
+++ b/Dockerfile.aarch64
@@ -17,7 +17,7 @@ RUN \
     /build-out/usr/bin \
     /tmp/qemu && \
   curl -o \
-  /tmp/qemu.deb -L \
+    /tmp/qemu.deb -L \
     "http://ftp.de.debian.org/debian/pool/main/q/qemu/qemu-user_${QEMU_VERSION}_arm64.deb" && \
   cd /tmp && \
   dpkg-deb -R \
@@ -27,7 +27,7 @@ RUN \
     /tmp/qemu/usr/bin/* \
     /build-out/qemu && \
   curl -o \
-  /build-out/usr/bin/qemu-binfmt-conf -L \
+    /build-out/usr/bin/qemu-binfmt-conf -L \
     "https://raw.githubusercontent.com/qemu/qemu/refs/heads/master/scripts/qemu-binfmt-conf.sh" && \
   chmod +x /build-out/usr/bin/qemu-binfmt-conf
 

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -124,7 +124,7 @@ pipeline {
       steps{
         script{
           env.EXT_RELEASE = sh(
-            script: ''' echo 9.0.2+ds-1~bpo12+1 ''',
+            script: ''' echo 9.1.1+ds-2~bpo12+1 ''',
             returnStdout: true).trim()
             env.RELEASE_LINK = 'custom_command'
         }

--- a/README.md
+++ b/README.md
@@ -67,4 +67,5 @@ docker run --rm -it \
 ```
 ## Versions
 
+* **07.11.24:** - Upgrade to 9.1.1, switch to new debian package and bin naming scheme.
 * **14.10.24:** - Initial release.

--- a/jenkins-vars.yml
+++ b/jenkins-vars.yml
@@ -3,7 +3,7 @@
 # jenkins variables
 project_name: docker-qemu-static
 external_type: na
-custom_version_command: "echo 9.0.2+ds-1~bpo12+1"
+custom_version_command: "echo 9.1.1+ds-2~bpo12+1"
 release_type: stable
 release_tag: latest
 ls_branch: master

--- a/readme-vars.yml
+++ b/readme-vars.yml
@@ -71,5 +71,6 @@ full_custom_readme: |
   ```
   ## Versions
 
+  * **07.11.24:** - Upgrade to 9.1.1, switch to new debian package and bin naming scheme.
   * **14.10.24:** - Initial release.
   {%- endraw %}

--- a/root/register
+++ b/root/register
@@ -15,4 +15,4 @@ if [ "${1}" = "--reset" ]; then
   find /proc/sys/fs/binfmt_misc -type f -name 'qemu-*' -exec sh -c 'echo -1 > {}' \;
 fi
 
-exec qemu-binfmt-conf --qemu-suffix "-static" --qemu-path "/qemu" $@
+exec qemu-binfmt-conf --qemu-path "/qemu" $@


### PR DESCRIPTION
With version 9.1.1, debian made the package `qemu-user-static` a compat/transitional package. The main package is moved to `qemu-user` and the bin names no longer have the suffix `-static` (the transitional package provides symlinks with the old suffix).

This PR switches to the new package `qemu-user` and adjusts the register script to drop the no longer used `-static` suffix.