### PR TITLE
check for artifacts before triggering build

### DIFF
--- a/.github/workflows/external_trigger.yml
+++ b/.github/workflows/external_trigger.yml
@@ -107,6 +107,11 @@ jobs:
             echo "New version \`${EXT_RELEASE}\` found; but there already seems to be an active build on Jenkins; exiting" >> $GITHUB_STEP_SUMMARY
             exit 0
           else
+            if curl -fL "http://deb.debian.org/debian/pool/main/q/qemu/qemu-user_${EXT_RELEASE}_amd64.deb" >/dev/null && curl -fL "http://deb.debian.org/debian/pool/main/q/qemu/qemu-user_${EXT_RELEASE}_arm64.deb" >/dev/null; then
+              artifacts_found="true"
+            else
+              artifacts_found="false"
+            fi
             if [[ "${artifacts_found}" == "false" ]]; then
               echo "> [!WARNING]" >> $GITHUB_STEP_SUMMARY
               echo "> New version detected, but not all artifacts are published yet; skipping trigger" >> $GITHUB_STEP_SUMMARY

--- a/jenkins-vars.yml
+++ b/jenkins-vars.yml
@@ -7,6 +7,12 @@ custom_version_command: "curl -sX GET https://deb.debian.org/debian/dists/bookwo
 release_type: stable
 release_tag: latest
 ls_branch: master
+external_artifact_check: |
+  if curl -fL "http://deb.debian.org/debian/pool/main/q/qemu/qemu-user_${EXT_RELEASE}_amd64.deb" >/dev/null && curl -fL "http://deb.debian.org/debian/pool/main/q/qemu/qemu-user_${EXT_RELEASE}_arm64.deb" >/dev/null; then
+    artifacts_found="true"
+  else
+    artifacts_found="false"
+  fi
 repo_vars:
   - BUILD_VERSION_ARG = 'QEMU_VERSION'
   - LS_USER = 'linuxserver'


### PR DESCRIPTION
Dev and PR builds will fail because the arm64 artifact is currently missing, but this PR will prevent unnecessary failling builds when merged