### PR TITLE
remove artifact check until jenkins-builder is fixed

### DIFF
--- a/.github/workflows/external_trigger.yml
+++ b/.github/workflows/external_trigger.yml
@@ -107,11 +107,6 @@ jobs:
             echo "New version \`${EXT_RELEASE}\` found; but there already seems to be an active build on Jenkins; exiting" >> $GITHUB_STEP_SUMMARY
             exit 0
           else
-            if curl -fL "http://deb.debian.org/debian/pool/main/q/qemu/qemu-user_${EXT_RELEASE}_amd64.deb" >/dev/null && curl -fL "http://deb.debian.org/debian/pool/main/q/qemu/qemu-user_${EXT_RELEASE}_arm64.deb" >/dev/null; then
-              artifacts_found="true"
-            else
-              artifacts_found="false"
-            fi
             if [[ "${artifacts_found}" == "false" ]]; then
               echo "> [!WARNING]" >> $GITHUB_STEP_SUMMARY
               echo "> New version detected, but not all artifacts are published yet; skipping trigger" >> $GITHUB_STEP_SUMMARY

--- a/jenkins-vars.yml
+++ b/jenkins-vars.yml
@@ -7,12 +7,6 @@ custom_version_command: "curl -sX GET https://deb.debian.org/debian/dists/bookwo
 release_type: stable
 release_tag: latest
 ls_branch: master
-external_artifact_check: |
-  if curl -fL "http://deb.debian.org/debian/pool/main/q/qemu/qemu-user_${EXT_RELEASE}_amd64.deb" >/dev/null && curl -fL "http://deb.debian.org/debian/pool/main/q/qemu/qemu-user_${EXT_RELEASE}_arm64.deb" >/dev/null; then
-    artifacts_found="true"
-  else
-    artifacts_found="false"
-  fi
 repo_vars:
   - BUILD_VERSION_ARG = 'QEMU_VERSION'
   - LS_USER = 'linuxserver'


### PR DESCRIPTION
Currently we sanitize the external version and overwrite the var, which results in the version being different than the one in the artifact name.

This PR removes the artifact check until we can fix that in the jenkins-builder.